### PR TITLE
feat: display desktop battery status on home device card

### DIFF
--- a/app/src/main/java/com/castle/sefirah/presentation/common/components/DeviceCard.kt
+++ b/app/src/main/java/com/castle/sefirah/presentation/common/components/DeviceCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import sefirah.common.R
+import sefirah.domain.model.BatteryState
 import sefirah.domain.model.ConnectionState
 import sefirah.domain.model.PairedDevice
 import sefirah.common.util.base64ToBitmap
@@ -40,6 +41,7 @@ fun DeviceCard(
     device: PairedDevice,
     onClick: () -> Unit,
     onSyncAction: () -> Unit,
+    battery: BatteryState? = null,
 ) {
     Card(
         onClick = onClick,
@@ -80,6 +82,29 @@ fun DeviceCard(
                         else -> stringResource(R.string.status_disconnected)
                     }
                     Text(text = connectionStateText, color = MaterialTheme.colorScheme.primary)
+
+                    if (device.connectionState.isConnected && battery != null) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(top = 2.dp)
+                        ) {
+                            Icon(
+                                painter = painterResource(
+                                    if (battery.isCharging) R.drawable.ic_battery_charging
+                                    else R.drawable.ic_battery
+                                ),
+                                contentDescription = stringResource(R.string.battery_status),
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text = stringResource(R.string.battery_level, battery.batteryLevel),
+                                color = MaterialTheme.colorScheme.primary,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
                 }
 
                 IconToggleButton(

--- a/app/src/main/java/com/castle/sefirah/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/castle/sefirah/presentation/home/HomeScreen.kt
@@ -39,6 +39,7 @@ fun HomeScreen(
     val activeSessions by viewModel.activeSessions.collectAsState()
     val audioDevices by viewModel.audioDevices.collectAsState()
     val actions by viewModel.actions.collectAsState()
+    val batteryByDevice by viewModel.batteryByDevice.collectAsState()
 
     // Bottom sheet state
     val scope = rememberCoroutineScope()
@@ -71,6 +72,7 @@ fun HomeScreen(
                 item(key = "devices") {
                     SwipeableDevicesCard(
                         devices = pairedDevicesList,
+                        batteryByDevice = batteryByDevice,
                         onDeviceSelected = { device ->
                             connectionViewModel.selectDevice(device)
                         },

--- a/app/src/main/java/com/castle/sefirah/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/castle/sefirah/presentation/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import sefirah.domain.model.ActionInfo
 import sefirah.domain.model.AudioDeviceInfo
+import sefirah.domain.model.BatteryState
 import sefirah.domain.model.MediaAction
 import sefirah.domain.model.MediaActionType
 import sefirah.domain.model.PlaybackInfo
@@ -18,6 +19,7 @@ import sefirah.domain.interfaces.DeviceManager
 import sefirah.domain.interfaces.NetworkManager
 import sefirah.projection.media.RemotePlaybackHandler
 import sefirah.network.extensions.ActionHandler
+import sefirah.network.extensions.RemoteDeviceStatusHandler
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,8 +27,12 @@ class HomeViewModel @Inject constructor(
     private val remotePlaybackHandler: RemotePlaybackHandler,
     private val deviceManager: DeviceManager,
     private val networkManager: NetworkManager,
-    actionHandler: ActionHandler
+    actionHandler: ActionHandler,
+    remoteDeviceStatusHandler: RemoteDeviceStatusHandler
 ) : ViewModel() {
+
+    val batteryByDevice: StateFlow<Map<String, BatteryState>> =
+        remoteDeviceStatusHandler.batteryByDevice
 
     val activeSessions: StateFlow<List<PlaybackInfo>> = deviceManager.selectedDeviceId
         .flatMapLatest { deviceId ->

--- a/app/src/main/java/com/castle/sefirah/presentation/home/components/SwipeableDevicesCard.kt
+++ b/app/src/main/java/com/castle/sefirah/presentation/home/components/SwipeableDevicesCard.kt
@@ -26,12 +26,14 @@ import androidx.navigation.NavController
 import com.castle.sefirah.navigation.SyncRoute
 import com.castle.sefirah.presentation.common.components.DeviceCard
 import sefirah.common.R
+import sefirah.domain.model.BatteryState
 import sefirah.domain.model.PairedDevice
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 fun SwipeableDevicesCard(
     devices: List<PairedDevice>,
+    batteryByDevice: Map<String, BatteryState>,
     onDeviceSelected: (PairedDevice) -> Unit,
     onSyncAction: (PairedDevice) -> Unit,
     onDeviceClick: (PairedDevice) -> Unit,
@@ -60,6 +62,7 @@ fun SwipeableDevicesCard(
                 key(device.deviceId) {
                     DeviceCard(
                         device = device,
+                        battery = batteryByDevice[device.deviceId],
                         onSyncAction = { onSyncAction(device) },
                         onClick = { onDeviceClick(device) },
                     )

--- a/core/common/src/main/res/drawable/ic_battery.xml
+++ b/core/common/src/main/res/drawable/ic_battery.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,880q-17,0 -28.5,-11.5T320,840v-680q0,-17 11.5,-28.5T360,120h80v-40q0,-17 11.5,-28.5T480,40q17,0 28.5,11.5T520,80v40h80q17,0 28.5,11.5T640,160v680q0,17 -11.5,28.5T600,880L360,880ZM400,800h160v-600L400,200v600Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/core/common/src/main/res/drawable/ic_battery_charging.xml
+++ b/core/common/src/main/res/drawable/ic_battery_charging.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,880q-17,0 -28.5,-11.5T320,840v-680q0,-17 11.5,-28.5T360,120h80v-40q0,-17 11.5,-28.5T480,40q17,0 28.5,11.5T520,80v40h80q17,0 28.5,11.5T640,160v680q0,17 -11.5,28.5T600,880L360,880ZM440,760l160,-240h-80v-160L360,600h80v160Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="version">Version</string>
     <string name="windows_app">Windows app</string>
     <string name="share_deep_link">Share to Desktop</string>
+    <string name="battery_level">%1$d%%</string>
+    <string name="battery_status">Battery status</string>
 
     <!-- Notifications Groups-->
     <string name="group_file_transfer">File Transfer</string>

--- a/core/network/src/main/java/sefirah/network/NetworkService.kt
+++ b/core/network/src/main/java/sefirah/network/NetworkService.kt
@@ -72,6 +72,7 @@ import sefirah.domain.model.RingerModeState
 import sefirah.domain.model.SocketMessage
 import sefirah.domain.util.MessageSerializer
 import sefirah.network.extensions.ActionHandler
+import sefirah.network.extensions.RemoteDeviceStatusHandler
 import sefirah.network.extensions.cancelPairingVerificationNotification
 import sefirah.network.extensions.handleMessage
 import sefirah.network.extensions.setNotification
@@ -112,6 +113,8 @@ class NetworkService : Service() {
     @Inject lateinit var smsHandler: SmsHandler
 
     @Inject lateinit var actionHandler: ActionHandler
+
+    @Inject lateinit var remoteDeviceStatusHandler: RemoteDeviceStatusHandler
 
     @Inject lateinit var deviceManager: DeviceManager
 
@@ -582,6 +585,7 @@ class NetworkService : Service() {
 
         remotePlaybackHandler.clearDeviceData(device.deviceId)
         actionHandler.clearDeviceActions(device.deviceId)
+        remoteDeviceStatusHandler.clearDeviceStatus(device.deviceId)
     }
 
     private suspend fun disconnectDevice(device: DiscoveredDevice) {

--- a/core/network/src/main/java/sefirah/network/extensions/MessageHandler.kt
+++ b/core/network/src/main/java/sefirah/network/extensions/MessageHandler.kt
@@ -11,6 +11,7 @@ import sefirah.domain.model.ApplicationList
 import sefirah.domain.model.AudioDeviceInfo
 import sefirah.domain.model.AudioStreamState
 import sefirah.domain.model.BaseRemoteDevice
+import sefirah.domain.model.BatteryState
 import sefirah.domain.model.BluetoothPairingRequest
 import sefirah.domain.model.BluetoothPairingResult
 import sefirah.domain.model.ClearNotifications
@@ -70,6 +71,7 @@ suspend fun NetworkService.handleMessage(device: BaseRemoteDevice, message: Sock
                 is AudioDeviceInfo -> remotePlaybackHandler.handleAudioDevice(device.deviceId, message)
                 is AudioStreamState -> setStreamVolume(device, message)
                 is ActionInfo -> actionHandler.addAction(device.deviceId, message)
+                is BatteryState -> remoteDeviceStatusHandler.updateBattery(device.deviceId, message)
                 is BluetoothPairingRequest -> handleBluetoothMakeDiscoverable(device.deviceId)
                 else -> {}
             }

--- a/core/network/src/main/java/sefirah/network/extensions/RemoteDeviceStatusHandler.kt
+++ b/core/network/src/main/java/sefirah/network/extensions/RemoteDeviceStatusHandler.kt
@@ -1,0 +1,28 @@
+package sefirah.network.extensions
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import sefirah.domain.model.BatteryState
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds volatile status reported by connected remote devices (e.g. the desktop's
+ * battery level). State is runtime-only and keyed by deviceId; it is cleared when
+ * a device disconnects.
+ */
+@Singleton
+class RemoteDeviceStatusHandler @Inject constructor() {
+    private val _batteryByDevice = MutableStateFlow<Map<String, BatteryState>>(emptyMap())
+    val batteryByDevice: StateFlow<Map<String, BatteryState>> = _batteryByDevice.asStateFlow()
+
+    fun updateBattery(deviceId: String, state: BatteryState) {
+        _batteryByDevice.update { it + (deviceId to state) }
+    }
+
+    fun clearDeviceStatus(deviceId: String) {
+        _batteryByDevice.update { it - deviceId }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the desktop's `feat: add battery service to report laptop battery status to connected devices` on
the Android side. The desktop already reports its battery via the existing `BatteryState` message, but Android
was silently dropping it (no branch in the dispatch `when`, so it fell through `else -> {}`).

## Changes

- **Dispatch**: `MessageHandler` now routes inbound `BatteryState` instead of dropping it.
- **State**: new `RemoteDeviceStatusHandler` (`@Singleton`) holds battery per device as a runtime `StateFlow`,
cleared on disconnect so a stale value never lingers.
- **UI**: `HomeViewModel` exposes the per-device battery map; `DeviceCard` renders a battery icon (charging /
normal) and percentage, shown only when the device is connected and has reported a value.

## Notes

- No wire-protocol change — the `BatteryState` message and serializer registration already matched the desktop.
- Battery is runtime-only state (not persisted to `PairedDeviceEntity`), matching how audio/playback/actions are
handled. A desktop with no battery sends nothing, so the indicator simply doesn't render.