### PR TITLE
fix: bind TCP client socket to Wi-Fi interface IP

### DIFF
--- a/core/network/src/main/java/sefirah/network/SocketFactoryImpl.kt
+++ b/core/network/src/main/java/sefirah/network/SocketFactoryImpl.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import sefirah.domain.interfaces.SocketFactory
 import sefirah.network.util.NetworkHelper.localAddress
 import sefirah.network.util.SslHelper
+import java.net.InetSocketAddress as JavaInetSocketAddress
+import java.net.Socket
 import javax.inject.Inject
 import javax.inject.Singleton
 import javax.net.ssl.SSLServerSocket
@@ -24,9 +26,20 @@ class SocketFactoryImpl @Inject constructor() : SocketFactory {
         return try {
             Log.d(TAG, "Connecting to $address:$port")
             val sslContext = SslHelper.sslContext(certificate)
+            val localAddr = localAddress
+            if (localAddr == null) {
+                Log.e(TAG, "No local IP address available — cannot bind socket")
+                return null
+            }
             withTimeoutOrNull(3000L) {
                 withContext(Dispatchers.IO) {
-                    (sslContext.socketFactory.createSocket(address, port) as SSLSocket).apply {
+                    val socket = Socket()
+                    socket.bind(JavaInetSocketAddress(localAddr, 0))
+                    socket.connect(JavaInetSocketAddress(address, port), 3000)
+                    Log.d(TAG, "Bound to $localAddr, connecting to $address:$port")
+                    (sslContext.socketFactory.createSocket(
+                        socket, address, port, true
+                    ) as SSLSocket).apply {
                         startHandshake()
                     }
                 }


### PR DESCRIPTION
## Problem

Outbound TCP connections from the Android app fail with `NoRouteToHostException` (GrapheneOS) or `ECONNABORTED` (Samsung One UI 8.5). The socket binds to `::` instead of the Wi-Fi interface IP.

## Root Cause

`sslContext.socketFactory.createSocket(address, port)` does not explicitly bind to a local address. Android uses the IPv6 unspecified address `::` as the local endpoint, which fails on some devices/Android versions.

## Fix

Explicitly bind to the Wi-Fi IP before connecting, using the existing `localAddress` helper:

```kotlin
val socket = Socket()
socket.bind(InetSocketAddress(localAddr, 0))
socket.connect(InetSocketAddress(address, port), 3000)
sslContext.socketFactory.createSocket(socket, address, port, true) as SSLSocket
```

## Testing

- GrapheneOS: previously `NoRouteToHostException`, now connects
- Cross-subnet (192.168.50.0/24 → 192.168.100.0/24 behind pfSense): works

## Related

Fixes https://github.com/shrimqy/Sefirah/issues/222