### PR TITLE
fix(notification): repost dismissed connection notification, add exit action

### DIFF
--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="notification_status_connected">Connected to %s</string>
     <string name="notification_disconnect_action">Disconnect</string>
     <string name="send_clipboard">Send clipboard</string>
+    <string name="notification_exit_action">Exit</string>
     <string name="notification_file_transfer_error">File Transfer Error</string>
     <string name="notification_file_transfer_complete">File Transfer Complete</string>
     <string name="notification_transfer_preparing">Preparing transfer…</string>

--- a/core/network/src/main/java/sefirah/network/NetworkService.kt
+++ b/core/network/src/main/java/sefirah/network/NetworkService.kt
@@ -44,6 +44,7 @@ import sefirah.communication.utils.ContactsHelper
 import sefirah.communication.utils.TelephonyHelper
 import sefirah.database.AppRepository
 import sefirah.domain.interfaces.DeviceManager
+import sefirah.domain.interfaces.NetworkManager
 import sefirah.domain.interfaces.PreferencesRepository
 import sefirah.domain.interfaces.SocketFactory
 import sefirah.FeatureManager
@@ -118,6 +119,8 @@ class NetworkService : Service() {
 
     @Inject lateinit var bluetoothPairingHandler: BluetoothPairingHandler
 
+    @Inject lateinit var networkManager: NetworkManager
+
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val binder = LocalBinder()
 
@@ -145,6 +148,9 @@ class NetworkService : Service() {
     private val connections = mutableMapOf<String, DeviceConnection>()
 
     private var tcpServerPort by Delegates.notNull<Int>()
+
+    private var lastNotificationDeviceName: String? = null
+    private var lastNotificationDeviceId: String? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
@@ -228,6 +234,14 @@ class NetworkService : Service() {
                     sendClipboardMessage(ClipboardInfo("text/plain", text))
                 }
             }
+
+            Actions.REPOST_NOTIFICATION.name -> {
+                setNotification(lastNotificationDeviceName, lastNotificationDeviceId, AppNotifications.DEVICE_CONNECTION_ID)
+            }
+
+            Actions.EXIT.name -> {
+                networkManager.stopService()
+            }
         }
         return START_STICKY
     }
@@ -255,8 +269,12 @@ class NetworkService : Service() {
                     val deviceNames = connectedDevices.joinToString(", ") { it.deviceName }
                     // Only pass deviceId for disconnect action when single device connected
                     val deviceId = if (connectedDevices.size == 1) connectedDevices.first().deviceId else null
+                    lastNotificationDeviceName = deviceNames
+                    lastNotificationDeviceId = deviceId
                     setNotification(deviceNames, deviceId, AppNotifications.DEVICE_CONNECTION_ID)
                 } else {
+                    lastNotificationDeviceName = null
+                    lastNotificationDeviceId = null
                     setNotification(null, null, AppNotifications.DEVICE_CONNECTION_ID)
                 }
             }
@@ -840,7 +858,9 @@ class NetworkService : Service() {
             DISCONNECT,
             CANCEL_TRANSFER,
             SEND_CLIPBOARD,
-            SEND_FILES
+            SEND_FILES,
+            REPOST_NOTIFICATION,
+            EXIT
         }
 
         val PORT_RANGE = 5150..5169

--- a/core/network/src/main/java/sefirah/network/extensions/NotificationHelper.kt
+++ b/core/network/src/main/java/sefirah/network/extensions/NotificationHelper.kt
@@ -97,6 +97,18 @@ fun NetworkService.setNotification(
     }
     val clipboardPendingIntent: PendingIntent = PendingIntent.getActivity(this, 0, clipboardIntent, PendingIntent.FLAG_IMMUTABLE)
 
+    // Fired when the notification is swiped away, e.g. by OEM skins that allow dismissing ongoing notifications
+    val repostIntent = Intent(this, NetworkService::class.java).apply {
+        action = Actions.REPOST_NOTIFICATION.name
+    }
+    val repostPendingIntent: PendingIntent = PendingIntent.getService(this, 0, repostIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+
+    // Exit action - fully stops the service
+    val exitIntent = Intent(this, NetworkService::class.java).apply {
+        action = Actions.EXIT.name
+    }
+    val exitPendingIntent: PendingIntent = PendingIntent.getService(this, 0, exitIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+
     val contentText =  if (deviceName.isNullOrEmpty()) {
         getString(R.string.notification_status_disconnected)
     } else getString(R.string.notification_status_connected, deviceName)
@@ -108,12 +120,13 @@ fun NetworkService.setNotification(
         setContentTitle(getString(R.string.notification_device_connection))
         setContentText(contentText)
         setContentIntent(mainPendingIntent)
+        setDeleteIntent(repostPendingIntent)
         setOngoing(true)
         setSilent(true)
         setShowWhen(false)
     }
 
-    // Only add actions if connected
+    // Only add connection-dependent actions if connected
     if (!deviceName.isNullOrEmpty()) {
         // Disconnect action - only if single device (deviceId provided)
         if (deviceId != null) {
@@ -126,6 +139,8 @@ fun NetworkService.setNotification(
         }
         notificationBuilder.addAction(R.drawable.ic_launcher_foreground, getString(R.string.send_clipboard), clipboardPendingIntent)
     }
+
+    notificationBuilder.addAction(R.drawable.ic_launcher_foreground, getString(R.string.notification_exit_action), exitPendingIntent)
 
     startForeground(notificationId, notificationBuilder.build())
 }


### PR DESCRIPTION
Some OEM skins let users swipe away the ongoing device-connection notification despite setOngoing(true). Add a deleteIntent that reposts it from the last known connection state.

Also add an explicit Exit action that fully stops NetworkService via NetworkManager.stopService(), giving users an intentional way to end the session instead of relying on the swipe gesture.