### PR TITLE
Feature: Added accessibility labels to some unlabeled icons

### DIFF
--- a/app/src/main/java/com/castle/sefirah/presentation/common/components/DeviceCard.kt
+++ b/app/src/main/java/com/castle/sefirah/presentation/common/components/DeviceCard.kt
@@ -18,7 +18,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -107,21 +111,31 @@ fun DeviceCard(
                     }
                 }
 
-                IconToggleButton(
-                    checked = device.connectionState.isConnected,
-                    onCheckedChange = { onSyncAction() },
-                    shapes = IconButtonDefaults.toggleableShapes(),
-                    colors = IconButtonDefaults.filledIconToggleButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                    ),
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                    tooltip = {
+                        PlainTooltip {
+                            Text(text = if (device.connectionState.isConnected) "Stop sync" else "Start sync")
+                        }
+                    },
+                    state = rememberTooltipState()
                 ) {
-                    Icon(
-                        painter = if (device.connectionState.isConnected) painterResource(R.drawable.ic_sync_disabled) else painterResource(R.drawable.ic_sync),
-                        contentDescription = if (device.connectionState.isConnected) "Stop sync" else "Start sync",
-                    )
+                    IconToggleButton(
+                        checked = device.connectionState.isConnected,
+                        onCheckedChange = { onSyncAction() },
+                        shapes = IconButtonDefaults.toggleableShapes(),
+                        colors = IconButtonDefaults.filledIconToggleButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                            checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        ),
+                    ) {
+                        Icon(
+                            painter = if (device.connectionState.isConnected) painterResource(R.drawable.ic_sync_disabled) else painterResource(R.drawable.ic_sync),
+                            contentDescription = if (device.connectionState.isConnected) "Stop sync" else "Start sync",
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/castle/sefirah/presentation/home/components/VolumeSlider.kt
+++ b/app/src/main/java/com/castle/sefirah/presentation/home/components/VolumeSlider.kt
@@ -17,6 +17,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -61,13 +64,23 @@ fun VolumeSlider(
             .fillMaxWidth()
             .padding(top = 8.dp)
     ) {
-        IconButton(onClick = toggleMute) {
-            Icon(
-                imageVector = if (isMuted) ImageVector.vectorResource(R.drawable.ic_volume_off_fill) else ImageVector.vectorResource(R.drawable.ic_volume_up_fill),
-                contentDescription = "Volume Icon",
-                tint = MaterialTheme.colorScheme.surfaceTint,
-                modifier = Modifier.size(24.dp).padding(start = 0.dp)
-            )
+        TooltipBox(
+            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+            tooltip = {
+                PlainTooltip {
+                    Text(text = if (isMuted) "Unmute" else "Mute")
+                }
+            },
+            state = rememberTooltipState()
+        ) {
+            IconButton(onClick = toggleMute) {
+                Icon(
+                    imageVector = if (isMuted) ImageVector.vectorResource(R.drawable.ic_volume_off_fill) else ImageVector.vectorResource(R.drawable.ic_volume_up_fill),
+                    contentDescription = if (isMuted) "Unmute" else "Mute",
+                    tint = MaterialTheme.colorScheme.surfaceTint,
+                    modifier = Modifier.size(24.dp).padding(start = 0.dp)
+                )
+            }
         }
         Slider(
             value = sliderPosition,

--- a/core/presentation/src/main/java/sefirah/presentation/components/AppTopBar.kt
+++ b/core/presentation/src/main/java/sefirah/presentation/components/AppTopBar.kt
@@ -7,9 +7,13 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -84,11 +88,21 @@ fun AppTopBar(
         },
         actions = {
             if (!active && selectedItem == 1) {
-                IconButton(onClick = { active = true }) {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "Search Icon"
-                    )
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                    tooltip = {
+                        PlainTooltip {
+                            Text(text = "Search")
+                        }
+                    },
+                    state = rememberTooltipState()
+                ) {
+                    IconButton(onClick = { active = true }) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = "Search"
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Added labels for volume mute/unmute icon, connection sync toggle ('start sync', 'stop sync'), and search icon in the devices tab.

- The labels appear when the icons are held down.

- Added for accessibility reasons.