### PR TITLE
fix: recover clipboard watcher after shizuku restart

### DIFF
--- a/features/src/main/java/sefirah/worker/WorkerManager.kt
+++ b/features/src/main/java/sefirah/worker/WorkerManager.kt
@@ -28,6 +28,17 @@ class WorkerManager @Inject constructor(
 
     private val userServiceArgs: Shizuku.UserServiceArgs by lazy { userServiceArgs() }
 
+    private val shizukuBinderReceivedListener = Shizuku.OnBinderReceivedListener {
+        if (watching) {
+            Log.i(TAG, "Shizuku binder received — restarting clipboard watcher")
+            startClipboardWatcher()
+        }
+    }
+
+    init {
+        Shizuku.addBinderReceivedListenerSticky(shizukuBinderReceivedListener)
+    }
+
     fun startClipboardWatcher() {
         watching = true
         thread(name = "sefirah-worker-start", isDaemon = true) {
@@ -101,6 +112,9 @@ class WorkerManager @Inject constructor(
                 Log.w(TAG, "Worker died")
                 if (w == null || worker === w || worker?.asBinder() == w.asBinder()) {
                     worker = null
+                    if (watching) {
+                        startClipboardWatcher()
+                    }
                 }
             }, 0)
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary

Fix clipboard synchronization not recovering after Shizuku restarts while the desktop connection remains active.

## Changes

- Listen for the Shizuku binder becoming available.
- Restart the clipboard watcher when Shizuku reconnects and clipboard monitoring is still active.
- Restart the watcher when the existing worker binder dies.

The change reuses the existing worker startup flow and does not require reconnecting the desktop connection.

## Related issue

Closes #87 